### PR TITLE
docs: added notice for nginx root path

### DIFF
--- a/packages/docs/guide/essentials/history-mode.md
+++ b/packages/docs/guide/essentials/history-mode.md
@@ -93,6 +93,15 @@ location / {
 }
 ```
 
+You may need to set the `root` path to prevent nginx internal redirection cycle if it cannot find `index.html`.
+
+```nginx
+location / {
+    root   /usr/share/nginx/html;
+    try_files $uri $uri/ /index.html;
+}
+```
+
 ### Native Node.js
 
 ```js


### PR DESCRIPTION
if nginx cannot find index.html inherently. It will end up in a loop with nginx access logs spitting out 
``rewrite or internal redirection cycle while internally redirecting to "/index.html"``